### PR TITLE
Setup webpacks

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+    "presets": ["env", "react"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ node_modules
 
 # config.js
 config.js
+
+# webpack destination directory
+dist

--- a/package.json
+++ b/package.json
@@ -11,18 +11,29 @@
     "server-dev": "nodemon server/server.js",
     "mongo-start": "sudo mongod --port 3002",
     "seed-db": "node database/seed.js",
-    "test": "jest --detectOpenHandles"
+    "test": "jest --detectOpenHandles",
+    "build-dev": "webpack --mode development --watch",
+    "build-prod": "webpack --mode production"
   },
   "dependencies": {
     "body-parser": "^1.18.3",
     "express": "^4.16.4",
     "mongoose": "^5.4.0",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "devDependencies": {
     "Faker": "^0.7.2",
     "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor",
     "jest": "^23.6.0",
-    "proxyquire": "^2.1.0"
+    "proxyquire": "^2.1.0",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.5",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-react": "^6.24.1",
+    "webpack": "^4.28.2",
+    "webpack-cli": "^3.1.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,22 @@
+const path = require('path');
+
+module.exports = {
+    entry: './client/src/index.jsx',
+    output: {
+        filename: 'bundle.js',
+        path: path.join(__dirname, './client/dist'),
+    },
+    module: {
+        rules: [
+            {
+                test: [/\.js$/, /\.jsx$/],
+                exclude: /node_modules/,
+                use:{
+                    loader: "babel-loader"
+                }
+            }
+        ]
+    }
+        
+
+}


### PR DESCRIPTION
 - add jest.config.js to set testing environment to 'node'
 - use proxyquire for mocking intenally 'requied' config.js file
 - use a 'test' database to avoid polluting actual database
 - rebased to updated master branch
@ngodavidhuy @Collin-St @worrierx0 
Please checkout this PR